### PR TITLE
🧪 [testing improvement] Add unit tests for SubscriptionDriver

### DIFF
--- a/tests/Methods/SubscriptionDriverTest.php
+++ b/tests/Methods/SubscriptionDriverTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 class MockSubscriptionDriver extends SubscriptionDriver
 {
     protected string $name = 'MockDriver';
+
     protected string $description = 'Mock Driver Description';
 
     public function getConfigs(): array
@@ -26,9 +27,9 @@ class MockSubscriptionDriver extends SubscriptionDriver
 
 class SubscriptionDriverTest extends TestCase
 {
-    public function testConfig()
+    public function test_config()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
         $driver->setConfigs(['key1' => 'value1', 'key2' => 2]);
 
         $this->assertEquals('value1', $driver->config('key1'));
@@ -36,9 +37,9 @@ class SubscriptionDriverTest extends TestCase
         $this->assertNull($driver->config('key3'));
     }
 
-    public function testSetConfigs()
+    public function test_set_configs()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
         $configs = ['foo' => 'bar'];
         $result = $driver->setConfigs($configs);
 
@@ -46,33 +47,33 @@ class SubscriptionDriverTest extends TestCase
         $this->assertEquals('bar', $driver->config('foo'));
     }
 
-    public function testGetName()
+    public function test_get_name()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
         $this->assertEquals('MockDriver', $driver->getName());
     }
 
-    public function testGetDescription()
+    public function test_get_description()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
         $this->assertEquals('Mock Driver Description', $driver->getDescription());
     }
 
-    public function testHasSandbox()
+    public function test_has_sandbox()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
         $this->assertTrue($driver->hasSandbox());
     }
 
-    public function testIsReturnInEmbed()
+    public function test_is_return_in_embed()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
         $this->assertFalse($driver->isReturnInEmbed());
     }
 
-    public function testGetConfigInMode()
+    public function test_get_config_in_mode()
     {
-        $driver = new MockSubscriptionDriver();
+        $driver = new MockSubscriptionDriver;
 
         // Test live mode (default)
         $driver->setConfigs([

--- a/tests/Methods/SubscriptionDriverTest.php
+++ b/tests/Methods/SubscriptionDriverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Juzaweb\Modules\Subscription\Tests\Methods;
+
+use Juzaweb\Modules\Subscription\Methods\SubscriptionDriver;
+use PHPUnit\Framework\TestCase;
+
+class MockSubscriptionDriver extends SubscriptionDriver
+{
+    protected string $name = 'MockDriver';
+    protected string $description = 'Mock Driver Description';
+
+    public function getConfigs(): array
+    {
+        return [
+            'key1' => 'Key 1',
+            'key2' => 'Key 2',
+        ];
+    }
+
+    public function callGetConfigInMode(string $key): array|int|string|null
+    {
+        return $this->getConfigInMode($key);
+    }
+}
+
+class SubscriptionDriverTest extends TestCase
+{
+    public function testConfig()
+    {
+        $driver = new MockSubscriptionDriver();
+        $driver->setConfigs(['key1' => 'value1', 'key2' => 2]);
+
+        $this->assertEquals('value1', $driver->config('key1'));
+        $this->assertEquals(2, $driver->config('key2'));
+        $this->assertNull($driver->config('key3'));
+    }
+
+    public function testSetConfigs()
+    {
+        $driver = new MockSubscriptionDriver();
+        $configs = ['foo' => 'bar'];
+        $result = $driver->setConfigs($configs);
+
+        $this->assertSame($driver, $result);
+        $this->assertEquals('bar', $driver->config('foo'));
+    }
+
+    public function testGetName()
+    {
+        $driver = new MockSubscriptionDriver();
+        $this->assertEquals('MockDriver', $driver->getName());
+    }
+
+    public function testGetDescription()
+    {
+        $driver = new MockSubscriptionDriver();
+        $this->assertEquals('Mock Driver Description', $driver->getDescription());
+    }
+
+    public function testHasSandbox()
+    {
+        $driver = new MockSubscriptionDriver();
+        $this->assertTrue($driver->hasSandbox());
+    }
+
+    public function testIsReturnInEmbed()
+    {
+        $driver = new MockSubscriptionDriver();
+        $this->assertFalse($driver->isReturnInEmbed());
+    }
+
+    public function testGetConfigInMode()
+    {
+        $driver = new MockSubscriptionDriver();
+
+        // Test live mode (default)
+        $driver->setConfigs([
+            'api_key' => 'live_key',
+            'sandbox_api_key' => 'sandbox_key',
+            'sandbox' => 0,
+        ]);
+        $this->assertEquals('live_key', $driver->callGetConfigInMode('api_key'));
+
+        // Test sandbox mode
+        $driver->setConfigs([
+            'api_key' => 'live_key',
+            'sandbox_api_key' => 'sandbox_key',
+            'sandbox' => 1,
+        ]);
+        $this->assertEquals('sandbox_key', $driver->callGetConfigInMode('api_key'));
+    }
+}


### PR DESCRIPTION
Add comprehensive unit tests for the `SubscriptionDriver` abstract class. Created a new test file `tests/Methods/SubscriptionDriverTest.php` and a mock implementation to verify configuration logic and property getters.

---
*PR created automatically by Jules for task [13674754784683961965](https://jules.google.com/task/13674754784683961965) started by @juzaweb*