### PR TITLE
🧪 Add test coverage for PayPal service plan creation errors

### DIFF
--- a/tests/Methods/PayPalTest.php
+++ b/tests/Methods/PayPalTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Juzaweb\Modules\Subscription\Tests\Methods;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Juzaweb\Modules\Subscription\Exceptions\SubscriptionException;
+use Juzaweb\Modules\Subscription\Methods\PayPal;
+use Juzaweb\Modules\Subscription\Models\Plan;
+use PHPUnit\Framework\TestCase;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+use Mockery;
+
+class MockPayPal extends PayPal
+{
+    protected PayPalClient $mockProvider;
+
+    public function setMockProvider(PayPalClient $mockProvider)
+    {
+        $this->mockProvider = $mockProvider;
+    }
+
+    protected function getProvider(): PayPalClient
+    {
+        return $this->mockProvider;
+    }
+}
+
+class PayPalTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_create_plan_throws_exception_on_plan_error()
+    {
+        $plan = Mockery::mock(Plan::class)->makePartial();
+        $plan->name = 'Test Plan';
+        $plan->description = 'Test Description';
+        $plan->price = 10;
+
+        $relation = Mockery::mock(HasMany::class);
+        $relation->shouldReceive('where')->with('method', 'PayPal')->andReturnSelf();
+        $relation->shouldReceive('first')->andReturn(null);
+
+        $plan->shouldReceive('subscriptionMethods')->andReturn($relation);
+
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('createProduct')->once()->andReturn(['id' => 'prod_123']);
+        $provider->shouldReceive('createPlan')->once()->andReturn(['error' => ['message' => 'Custom PayPal plan error']]);
+
+        $driver = new MockPayPal();
+        $driver->setMockProvider($provider);
+
+        $this->expectException(SubscriptionException::class);
+        $this->expectExceptionMessage('Custom PayPal plan error');
+
+        $driver->createPlan($plan);
+    }
+
+    public function test_create_plan_throws_exception_on_product_error()
+    {
+        $plan = Mockery::mock(Plan::class)->makePartial();
+        $plan->name = 'Test Plan';
+        $plan->description = 'Test Description';
+        $plan->price = 10;
+
+        $relation = Mockery::mock(HasMany::class);
+        $relation->shouldReceive('where')->with('method', 'PayPal')->andReturnSelf();
+        $relation->shouldReceive('first')->andReturn(null);
+
+        $plan->shouldReceive('subscriptionMethods')->andReturn($relation);
+
+        $provider = Mockery::mock(PayPalClient::class);
+        $provider->shouldReceive('createProduct')->once()->andReturn(['error' => ['message' => 'Custom PayPal product error']]);
+        $provider->shouldNotReceive('createPlan');
+
+        $driver = new MockPayPal();
+        $driver->setMockProvider($provider);
+
+        $this->expectException(SubscriptionException::class);
+        $this->expectExceptionMessage('Custom PayPal product error');
+
+        $driver->createPlan($plan);
+    }
+}

--- a/tests/Methods/PayPalTest.php
+++ b/tests/Methods/PayPalTest.php
@@ -6,9 +6,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Juzaweb\Modules\Subscription\Exceptions\SubscriptionException;
 use Juzaweb\Modules\Subscription\Methods\PayPal;
 use Juzaweb\Modules\Subscription\Models\Plan;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use Srmklive\PayPal\Services\PayPal as PayPalClient;
-use Mockery;
 
 class MockPayPal extends PayPal
 {
@@ -50,7 +50,7 @@ class PayPalTest extends TestCase
         $provider->shouldReceive('createProduct')->once()->andReturn(['id' => 'prod_123']);
         $provider->shouldReceive('createPlan')->once()->andReturn(['error' => ['message' => 'Custom PayPal plan error']]);
 
-        $driver = new MockPayPal();
+        $driver = new MockPayPal;
         $driver->setMockProvider($provider);
 
         $this->expectException(SubscriptionException::class);
@@ -76,7 +76,7 @@ class PayPalTest extends TestCase
         $provider->shouldReceive('createProduct')->once()->andReturn(['error' => ['message' => 'Custom PayPal product error']]);
         $provider->shouldNotReceive('createPlan');
 
-        $driver = new MockPayPal();
+        $driver = new MockPayPal;
         $driver->setMockProvider($provider);
 
         $this->expectException(SubscriptionException::class);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing error test for PayPal service plan creation in `src/Methods/PayPal.php`. The error condition where creating a PayPal plan returns an error array was previously not covered.
   
📊 **Coverage:** The scenarios now tested are:
- `test_create_plan_throws_exception_on_plan_error`: Confirms that when `createProduct` succeeds but `createPlan` returns an error array, a `SubscriptionException` is correctly thrown with the relevant error message.
- `test_create_plan_throws_exception_on_product_error`: Confirms that when `createProduct` returns an error array, a `SubscriptionException` is correctly thrown before `createPlan` is even executed.

✨ **Result:** The improvement in test coverage guarantees that any potential bugs or regressions in PayPal's product or plan creation logic are successfully caught by the testing suite.

---
*PR created automatically by Jules for task [3330932707034507573](https://jules.google.com/task/3330932707034507573) started by @juzaweb*