### PR TITLE
🧪 Add PayPal webhook error test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "orchestra/testbench": "^8.0|^9.0",
         "phpunit/phpunit": "^10.0",
         "juzaweb/core": "^5.0",
-        "laravel/pint": "^1.29"
+        "laravel/pint": "^1.29",
+        "srmklive/paypal": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Methods/PayPalTest.php
+++ b/tests/Methods/PayPalTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Juzaweb\Modules\Subscription\Tests\Methods;
+
+use Illuminate\Http\Request;
+use Juzaweb\Modules\Subscription\Exceptions\SubscriptionException;
+use Juzaweb\Modules\Subscription\Methods\PayPal;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Srmklive\PayPal\Services\PayPal as PayPalClient;
+
+class MockPayPalDriver extends PayPal
+{
+    protected PayPalClient $mockProvider;
+
+    protected LoggerInterface $mockLogger;
+
+    public function setMockProvider(PayPalClient $provider)
+    {
+        $this->mockProvider = $provider;
+    }
+
+    public function setMockLogger(LoggerInterface $logger)
+    {
+        $this->mockLogger = $logger;
+    }
+
+    protected function getProvider(): PayPalClient
+    {
+        return $this->mockProvider;
+    }
+
+    protected function getLogger()
+    {
+        return $this->mockLogger;
+    }
+}
+
+class PayPalTest extends TestCase
+{
+    public function test_webhook_throws_exception_on_invalid_signature()
+    {
+        // Setup
+        $driver = new MockPayPalDriver;
+        $driver->setConfigs(['webhook_id' => 'test_webhook_id']);
+
+        $mockProvider = $this->createMock(PayPalClient::class);
+        $mockProvider->expects($this->once())
+            ->method('verifyWebHook')
+            ->willReturn(['verification_status' => 'FAILURE']); // Or any array without SUCCESS
+
+        $driver->setMockProvider($mockProvider);
+
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->once())
+            ->method('error')
+            ->with('Invalid webhook signature', $this->anything());
+
+        $driver->setMockLogger($mockLogger);
+
+        $request = Request::create('/webhook', 'POST', [], [], [], [
+            'HTTP_PAYPAL-AUTH-ALGO' => 'algo',
+            'HTTP_PAYPAL-CERT-URL' => 'url',
+            'HTTP_PAYPAL-TRANSMISSION-ID' => 'id',
+            'HTTP_PAYPAL-TRANSMISSION-SIG' => 'sig',
+            'HTTP_PAYPAL-TRANSMISSION-TIME' => 'time',
+        ], json_encode(['event_type' => 'PAYMENT.SALE.COMPLETED']));
+
+        $this->expectException(SubscriptionException::class);
+        $this->expectExceptionMessage('Invalid webhook signature');
+
+        // Execute
+        $driver->webhook($request);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing error test for PayPal webhook validation in the `PayPal` driver. Specifically, it tests the path where the `verification_status` returned by the provider is not `SUCCESS`, which throws a `SubscriptionException` and logs an error.

📊 **Coverage:** What scenarios are now tested
A new test case `test_webhook_throws_exception_on_invalid_signature` in `tests/Methods/PayPalTest.php` has been added. It:
1. Mocks the `PayPalClient` provider to return `['verification_status' => 'FAILURE']`.
2. Mocks the `LoggerInterface` to verify the error is logged correctly.
3. Asserts that a `SubscriptionException` is thrown with the expected message `Invalid webhook signature`.
4. Required the dependency `srmklive/paypal` as a dev-dependency to mock it properly.

✨ **Result:** The improvement in test coverage
The exception path for an invalid webhook signature in the `PayPal` driver is now fully tested. Running the test suite shows all 10 tests now pass (up from 9).

---
*PR created automatically by Jules for task [5482320399232223927](https://jules.google.com/task/5482320399232223927) started by @juzaweb*