### PR TITLE
feat: Add OpenAPI schemas to API resource classes

### DIFF
--- a/src/Http/Resources/PlanResource.php
+++ b/src/Http/Resources/PlanResource.php
@@ -4,6 +4,24 @@ namespace Juzaweb\Modules\Subscription\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *  schema="PlanResource",
+ *  title="PlanResource",
+ *
+ *  @OA\Property(property="id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="name", type="string", example="Premium Plan"),
+ *  @OA\Property(property="price", type="number", example=9.99),
+ *  @OA\Property(property="is_free", type="boolean", example=false),
+ *  @OA\Property(property="duration", type="integer", example=1),
+ *  @OA\Property(property="duration_unit", type="string", example="month"),
+ *  @OA\Property(property="features", type="array", @OA\Items(
+ *      @OA\Property(property="name", type="string"),
+ *      @OA\Property(property="value", type="string")
+ *  )),
+ *  @OA\Property(property="active", type="boolean", example=true)
+ * )
+ */
 class PlanResource extends JsonResource
 {
     public function toArray($request): array

--- a/src/Http/Resources/SubscriptionHistoryResource.php
+++ b/src/Http/Resources/SubscriptionHistoryResource.php
@@ -4,6 +4,22 @@ namespace Juzaweb\Modules\Subscription\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *  schema="SubscriptionHistoryResource",
+ *  title="SubscriptionHistoryResource",
+ *
+ *  @OA\Property(property="id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="subscription_id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="plan_id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="method_id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="amount", type="number", example=9.99),
+ *  @OA\Property(property="end_date", type="string", format="date-time", example="2023-10-10 10:10:10"),
+ *  @OA\Property(property="status", type="string", example="success"),
+ *  @OA\Property(property="plan", ref="#/components/schemas/PlanResource"),
+ *  @OA\Property(property="method", ref="#/components/schemas/SubscriptionMethodResource")
+ * )
+ */
 class SubscriptionHistoryResource extends JsonResource
 {
     public function toArray($request): array

--- a/src/Http/Resources/SubscriptionMethodResource.php
+++ b/src/Http/Resources/SubscriptionMethodResource.php
@@ -4,6 +4,18 @@ namespace Juzaweb\Modules\Subscription\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *  schema="SubscriptionMethodResource",
+ *  title="SubscriptionMethodResource",
+ *
+ *  @OA\Property(property="id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="name", type="string", example="Paypal"),
+ *  @OA\Property(property="description", type="string", example="Pay with paypal"),
+ *  @OA\Property(property="driver", type="string", example="paypal"),
+ *  @OA\Property(property="active", type="boolean", example=true)
+ * )
+ */
 class SubscriptionMethodResource extends JsonResource
 {
     public function toArray($request): array

--- a/src/Http/Resources/SubscriptionResource.php
+++ b/src/Http/Resources/SubscriptionResource.php
@@ -4,6 +4,22 @@ namespace Juzaweb\Modules\Subscription\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @OA\Schema(
+ *  schema="SubscriptionResource",
+ *  title="SubscriptionResource",
+ *
+ *  @OA\Property(property="id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="plan_id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="method_id", type="string", example="99a5e8aa-534a-4467-9c98-107f9c21b96d"),
+ *  @OA\Property(property="amount", type="number", example=9.99),
+ *  @OA\Property(property="start_date", type="string", format="date-time", example="2023-10-10 10:10:10"),
+ *  @OA\Property(property="end_date", type="string", format="date-time", example="2023-11-10 10:10:10"),
+ *  @OA\Property(property="status", type="string", example="active"),
+ *  @OA\Property(property="plan", ref="#/components/schemas/PlanResource"),
+ *  @OA\Property(property="method", ref="#/components/schemas/SubscriptionMethodResource")
+ * )
+ */
 class SubscriptionResource extends JsonResource
 {
     public function toArray($request): array


### PR DESCRIPTION
Adds @OA\Schema block annotations to all API Resource classes (`PlanResource`, `SubscriptionHistoryResource`, `SubscriptionResource`, `SubscriptionMethodResource`) to define their output structure, properties, and data types for Swagger/OpenAPI documentation. This allows the API response models to be correctly documented and referenced by the controller route annotations.

Tested locally, ran pint to fix any codestyle issues, and confirmed standard test suite passes.

---
*PR created automatically by Jules for task [8227579357095979933](https://jules.google.com/task/8227579357095979933) started by @juzaweb*