### PR TITLE
🧹 remove unused taxes configuration in PayPal createPlan

### DIFF
--- a/src/Methods/PayPal.php
+++ b/src/Methods/PayPal.php
@@ -79,10 +79,6 @@ class PayPal extends SubscriptionDriver implements SubscriptionMethod
                     'setup_fee_failure_action' => 'CONTINUE',
                     'payment_failure_threshold' => 3,
                 ],
-                // 'taxes' => [
-                //     'percentage' => '10',
-                //     'inclusive' => false
-                // ]
             ]
         );
 


### PR DESCRIPTION
🎯 **What:** Removed unused, commented-out 'taxes' configuration in `src/Methods/PayPal.php`.
💡 **Why:** Dead code in the form of commented-out blocks should be removed to keep the codebase clean and improve maintainability.
✅ **Verification:** Ran the full test suite (`vendor/bin/phpunit`) and code style checks (`vendor/bin/pint --test`). Both passed successfully.
✨ **Result:** A cleaner and more readable `src/Methods/PayPal.php` file.

---
*PR created automatically by Jules for task [8468714941087544550](https://jules.google.com/task/8468714941087544550) started by @juzaweb*